### PR TITLE
Add OpenFreeMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@
 | [Geolonia](https://www.geolonia.com/) | [Midnight](https://geoloniamaps.github.io/midnight/) | Geolonia Maps | ? | MIT | [Charites](https://github.com/geoloniamaps/midnight)
 | [Geolonia](https://www.geolonia.com/) | [Red Planet](https://geoloniamaps.github.io/red-planet/) | Geolonia Maps | ? | MIT | [Charites](https://github.com/geoloniamaps/red-planet)
 | [Geolonia](https://www.geolonia.com/) | [Notebook](https://geoloniamaps.github.io/notebook/) | Geolonia Maps | ? | MIT | [Charites](https://github.com/geoloniamaps/notebook)
+| [OpenFreeMap](https://openfreemap.org/) | [Bright](https://github.com/hyperknot/openfreemap-styles) | OpenMapTiles | CC BY[^notmap] | BSD | [MapLibre JSON](https://github.com/hyperknot/openfreemap-styles/)
+| [OpenFreeMap](https://openfreemap.org/) | [Liberty](https://github.com/hyperknot/openfreemap-styles) | OpenMapTiles | CC BY[^notmap] | BSD | [MapLibre JSON](https://github.com/hyperknot/openfreemap-styles/)
+| [OpenFreeMap](https://openfreemap.org/) | [Positron](https://github.com/hyperknot/openfreemap-styles) | OpenMapTiles | CC BY[^notmap] | BSD | [MapLibre JSON](https://github.com/hyperknot/openfreemap-styles/)
+| [OpenFreeMap](https://openfreemap.org/) | [Dark](https://github.com/hyperknot/openfreemap-styles) | OpenMapTiles | CC BY[^notmap] | BSD | [MapLibre JSON](https://github.com/hyperknot/openfreemap-styles/)
+| [OpenFreeMap](https://openfreemap.org/) | [Fiord](https://github.com/hyperknot/openfreemap-styles) | OpenMapTiles | CC BY[^notmap] | BSD | [MapLibre JSON](https://github.com/hyperknot/openfreemap-styles/)
 
 [^notmap]: Style attribution may be provided from a linked page and need not be present on the map itself
 [^positroncc0]: [Contradictory information is available on the license](https://github.com/openmaptiles/positron-gl-style/issues/22)


### PR DESCRIPTION
While all of these styles are forks of the vanilla OMT styles, they have diverged from upstream. Notably, Bright uses the same icons as Liberty.